### PR TITLE
Removed redundant username from profile

### DIFF
--- a/event-app/src/routes/ProfilePage.js
+++ b/event-app/src/routes/ProfilePage.js
@@ -110,7 +110,6 @@ function ProfilePage() {
         <>
           <h1 className='PageTitle'>{user.username}</h1>
           <div className="UserInfo">
-            <p><strong>Username:</strong> {user.username}</p>
             {!isOwner && (
               isFriend ? (
                 <Button 


### PR DESCRIPTION
Removed redundant username from profile. Username was displayed twice (1: Page title, 2: as profile information)